### PR TITLE
Add HMFF energy

### DIFF
--- a/version_2.1/dts_src/HMFFEnergy.cpp
+++ b/version_2.1/dts_src/HMFFEnergy.cpp
@@ -1,0 +1,148 @@
+/*
+  Compute the energy of a whole system in a scalar field using HMFF.
+
+  Copyright (c) 2024-2025 European Molecular Biology Laboratory
+
+  Author: Valentin Maurer <valentin.maurer@embl-hamburg.de>
+*/
+#include "HMFFEnergy.h"
+#include "Nfunction.h"
+#include "State.h"
+#include <time.h>
+#include <sstream>
+
+HMFFEnergy::HMFFEnergy(State *pState, std::string data) : Energy(pState){
+  std::vector<std::string> ndata = Nfunction::Split(data);
+
+  if(ndata.size() < 5 || ndata.size() > 8){
+    std::cerr << "MDFF Energy Parameters:\n"
+              << "  Required: path xi theta_thr scaling offset\n"
+              << "  Optional: [inversion] [step_size] [padding_factor] [kernel_size] [data_percentile]\n\n"
+              << "  path       : Path to MRC file containing EM density map\n"
+              << "  xi         : Force scaling factor (typical: 1.0-50.0)\n"
+              << "  theta_thr  : Threshold value to exclude solvent contribution (typical 0.0) \n"
+              << "  scaling    : Mesh scaling factor for distance/voxel conversion\n"
+              << "  offset     : Grid offset (single value or comma-separated x,y,z)\n"
+              << "  inversion  : Invert density contrast (0=false, 1=true, default: 1)\n"
+              << "  step_size  : Step size along gradient (default: 0.0)\n"
+              << "  padding    : Scaling factor for boundary padding (default: 0.4)\n"
+              << "  kernel     : Gradient kernel size, must be odd (default: 3)\n"
+              << "  percentile : theta_max determined as percentile of data (0.0-1.0, default: 0.999)\n\n"
+              << "Examples:\n"
+              << "  Basic: path.mrc 5.0 0 0.005 24.0\n"
+              << "  Full:  path.mrc 5.0 0 0.005 24.0 1 0.0 0.4\n";
+    exit(1);
+  }
+
+  // Required parameters
+  const double xi = (float) Nfunction::String_to_Double(ndata[1]);
+  const double theta_thr = (float) Nfunction::String_to_Double(ndata[2]);
+  const double mesh_scaling = Nfunction::String_to_Double(ndata[3]);
+
+  // Parse mesh offset from (0,0,0).
+  std::vector<double> offsets;
+  std::istringstream ss(ndata[4]);
+  std::string value;
+  std::vector<std::string> offset_parts;
+  while (std::getline(ss, value, ',')) {
+    offset_parts.push_back(value);
+  }
+
+  if (offset_parts.size() == 1) {
+    double single_offset = Nfunction::String_to_Double(offset_parts[0]);
+    offsets = {single_offset, single_offset, single_offset};
+  } else if (offset_parts.size() == 3) {
+    offsets = {
+      Nfunction::String_to_Double(offset_parts[0]),
+      Nfunction::String_to_Double(offset_parts[1]),
+      Nfunction::String_to_Double(offset_parts[2])
+    };
+  } else {
+    std::cerr << "Error: offset must be either a single value or three comma-separated values (x,y,z)\n";
+    exit(1);
+  }
+
+  double data_scaling = 1.0;
+  if (ndata.size() >= 6) {
+    if ((bool) Nfunction::String_to_Double(ndata[5])) {
+      data_scaling = -1.0;
+    }
+  }
+
+  const double step_size = (ndata.size() >= 7) ?
+    (double) Nfunction::String_to_Double(ndata[6]) : 0.0;
+
+  const float padding_factor = (ndata.size() >= 8) ?
+    (float) Nfunction::String_to_Double(ndata[7]) : 0.4;
+
+  unsigned int kernel_size = 3;
+  if (ndata.size() >= 9) {
+    kernel_size = (unsigned int) Nfunction::String_to_Double(ndata[8]);
+    if (kernel_size % 2 == 0) {
+      std::cerr << "Error: kernel_size must be odd (got " << kernel_size << ")\n";
+      exit(1);
+    }
+    if (kernel_size < 3) {
+      std::cerr << "Error: kernel_size must be >= 3 (got " << kernel_size << ")\n";
+      exit(1);
+    }
+  }
+
+  float data_percentile = 0.999f; // Default
+  if (ndata.size() >= 10) {
+    data_percentile = (float) Nfunction::String_to_Double(ndata[9]);
+    if (data_percentile <= 0.0f || data_percentile >= 1.0f) {
+      std::cerr << "Error: data_percentile must be between 0.0 and 1.0 (got "
+                << data_percentile << ")\n";
+      exit(1);
+    }
+  }
+
+  MRCParser parser(ndata[0]);
+  const std::vector<float> &mrcData = parser.getData();
+  std::vector<int32_t> int32t_shape = parser.getShape();
+  const std::vector<unsigned int> shape(int32t_shape.begin(), int32t_shape.end());
+  std::vector<float> float_sampling = parser.getSampling();
+  std::vector<double> sampling(float_sampling.begin(), float_sampling.end());
+
+  // Transform mesh to 1U/Voxel and then bin to SamplingU/Voxel
+  for (size_t i = 0; i < sampling.size(); i++) {
+      sampling[i] *= mesh_scaling;
+      sampling[i] = 1 / sampling[i];
+  }
+
+  m_pCalculator = new HarmonicPotentialCalculator(
+    mrcData, shape, sampling, xi, theta_thr, offsets, data_scaling, step_size,
+    kernel_size, data_percentile, padding_factor
+  );
+  if (m_pCalculator == nullptr) {
+    std::cerr << "Error: Failed to allocate memory for "
+                 "Inclusion_Interaction_Map \n";
+    exit(1);
+  }
+}
+
+Vec3D HMFFEnergy::CalculateGradient(vertex *p_vertex) {
+    const std::array<double, 3> grad = m_pCalculator->computeEnergyGradient(
+        p_vertex->GetXPos(), p_vertex->GetYPos(), p_vertex->GetZPos()
+    );
+    return Vec3D(grad[0], grad[1], grad[2]);
+}
+
+
+double HMFFEnergy::SingleVertexEnergy(vertex *p_vertex) {
+    // Get the standard energy from the base Energy class
+    double energy = Energy::SingleVertexEnergy(p_vertex);
+
+    // Add HMFF contribution
+    energy += m_pCalculator->computeEnergy(
+        p_vertex->GetXPos(), p_vertex->GetYPos(), p_vertex->GetZPos()
+    );
+
+    // Update the vertex with the new total energy
+    // Note: we are updating the vertex energy twice. This could be avoided
+    // by making the corresponding members in Energy non-private or re-implementing
+    // them here, risking synchronization issues in the future.
+    p_vertex->UpdateEnergy(energy);
+    return energy;
+}

--- a/version_2.1/dts_src/HMFFEnergy.cpp
+++ b/version_2.1/dts_src/HMFFEnergy.cpp
@@ -14,7 +14,7 @@
 HMFFEnergy::HMFFEnergy(State *pState, std::string data) : Energy(pState){
   std::vector<std::string> ndata = Nfunction::Split(data);
 
-  if(ndata.size() < 5 || ndata.size() > 8){
+  if(ndata.size() < 5 || ndata.size() > 10){
     std::cerr << "MDFF Energy Parameters:\n"
               << "  Required: path xi theta_thr scaling offset\n"
               << "  Optional: [inversion] [step_size] [padding_factor] [kernel_size] [data_percentile]\n\n"
@@ -30,7 +30,7 @@ HMFFEnergy::HMFFEnergy(State *pState, std::string data) : Energy(pState){
               << "  percentile : theta_max determined as percentile of data (0.0-1.0, default: 0.999)\n\n"
               << "Examples:\n"
               << "  Basic: path.mrc 5.0 0 0.005 24.0\n"
-              << "  Full:  path.mrc 5.0 0 0.005 24.0 1 0.0 0.4\n";
+              << "  Full:  path.mrc 5.0 0 0.005 24.0 1 0.0 0.4 3 0.999\n";
     exit(1);
   }
 

--- a/version_2.1/dts_src/HMFFEnergy.h
+++ b/version_2.1/dts_src/HMFFEnergy.h
@@ -1,0 +1,41 @@
+/*
+  Compute the energy of a whole system in a scalar field using HMFF.
+
+  Copyright (c) 2024-2025 European Molecular Biology Laboratory
+
+  Author: Valentin Maurer <valentin.maurer@embl-hamburg.de>
+*/
+#if !defined(AFX_Energy_H_334B21B8_C13C_2248_BF23_347859023452__INCLUDED_)
+#define AFX_Energy_H_334B21B8_C13C_2248_BF23_347859023452__INCLUDED_
+
+#include "SimDef.h"
+#include "vertex.h"
+#include "triangle.h"
+#include "links.h"
+#include "Inclusion_Interaction_Map.h"
+#include "Energy.h"
+
+#include "VertexInScalarFieldPotential.cpp"
+#include "MRCParser.cpp"
+
+class State;
+class HMFFEnergy : public Energy {
+public:
+  HMFFEnergy(State *pState, std::string);
+
+  ~HMFFEnergy(){
+      delete m_pCalculator;
+    }
+
+public:
+  inline std::string GetDerivedDefaultReadName() override { return "FreeDTS1.0_MDFF"; }
+  inline static std::string GetDefaultReadName() { return "FreeDTS1.0_MDFF"; }
+
+  double SingleVertexEnergy(vertex *p) override;
+  Vec3D CalculateGradient(vertex *p_vertex);
+
+private:
+  HarmonicPotentialCalculator *m_pCalculator = nullptr;
+};
+
+#endif

--- a/version_2.1/dts_src/MRCParser.cpp
+++ b/version_2.1/dts_src/MRCParser.cpp
@@ -1,0 +1,109 @@
+/*
+  Parser for the CCP4/MRC format.
+
+  Copyright (c) 202-2025 European Molecular Biology Laboratory
+
+  Author: Valentin Maurer <valentin.maurer@embl-hamburg.de>
+*/
+#include <algorithm>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <iostream>
+#include <cstdint>
+
+template <typename T> float to_float(T c) { return static_cast<float>(c); }
+
+class MRCParser {
+private:
+  struct Header {
+    int32_t nx, ny, nz;                // 12
+    int32_t mode;                      // 16
+    int32_t nxstart, nystart, nzstart; // 28
+    float mx, my, mz;                  // 40
+    float cella[3], cellb[3];          // 64
+    int32_t mapc, mapr, maps;          // 64
+    float dmin, dmax, dmean;           // 76
+    int32_t ispg;                      // 88
+    int32_t nsymbt;                    // 96
+    char extra[100];                   // 196
+    int32_t originx, originy, originz; // 208
+    char map[4];                       // 212
+    int32_t machst;                    // 216
+    float rms;                         // 220
+    int32_t nlabl;                     // 224
+    char label[800];                   // 1024
+  };
+
+  Header m_Header;
+  std::vector<float> m_Data;
+
+  template <typename T>
+  void readData(std::ifstream &file, size_t dataSize) {
+      m_Data.resize(dataSize);
+
+      const size_t chunkSize = std::min(dataSize, size_t(1024 * 1024 * 64));
+      std::vector<T> buffer(chunkSize);
+
+      for (size_t offset = 0; offset < dataSize; offset += chunkSize) {
+          size_t currentChunkSize = std::min(chunkSize, dataSize - offset);
+          buffer.resize(currentChunkSize);
+          file.read(reinterpret_cast<char *>(buffer.data()), currentChunkSize * sizeof(T));
+          std::transform(buffer.begin(), buffer.end(), m_Data.begin() + offset, to_float<T>);
+      }
+  }
+
+  void readFile(const std::string &filename) {
+    std::ifstream file(filename, std::ios::binary);
+    if (!file) {
+      std::cerr << "Cannot open file: " + filename + "\n";
+      exit(1);
+    }
+
+    file.read(reinterpret_cast<char *>(&m_Header), sizeof(m_Header));
+    if (std::string(m_Header.map, 4) != "MAP ") {
+      std::cerr << "Invalid MRC file: MAP m_Header not found\n";
+      exit(1);
+    }
+
+    // Factor in extended header
+    if (m_Header.nsymbt > 0) {
+      file.seekg(m_Header.nsymbt, std::ios::cur);
+    }
+
+    size_t dataSize = m_Header.nx * m_Header.ny * m_Header.nz;
+
+    switch (m_Header.mode) {
+    case 0: // 8-bit signed integer
+      readData<int8_t>(file, dataSize);
+      break;
+    case 1: // 16-bit signed integer
+      readData<int16_t>(file, dataSize);
+      break;
+    case 2: // 32-bit float
+      readData<float>(file, dataSize);
+      break;
+    case 6: // 16-bit unsigned integer
+      readData<uint16_t>(file, dataSize);
+      break;
+    default:
+      std::cerr << "Unsupported MODE: " + std::to_string(m_Header.mode);
+      exit(1);
+    }
+  }
+
+public:
+  MRCParser(const std::string &filename) { readFile(filename); }
+
+  const std::vector<float> &getData() const { return m_Data; }
+  const std::vector<int32_t> getShape() const {
+    const std::vector<int32_t> shape = {m_Header.nx, m_Header.ny, m_Header.nz};
+    return shape;
+  }
+  const std::vector<float> getSampling() const {
+    const std::vector<float> sampling = {m_Header.cella[0] / m_Header.nx,
+                                      m_Header.cella[1] / m_Header.ny,
+                                      m_Header.cella[2] / m_Header.nz};
+    return sampling;
+  }
+};

--- a/version_2.1/dts_src/State.cpp
+++ b/version_2.1/dts_src/State.cpp
@@ -787,6 +787,10 @@ while (input >> firstword) {
             input >> str >> type;
             if(type == Energy::GetDefaultReadName()){ // "FreeDTS1.0_FF"
                 m_pEnergyCalculator = new Energy(this);  // Initialize EnergyCalculator
+            }else if(type == HMFFEnergy::GetDefaultReadName()){
+                std::string data;
+                getline(input, data);
+                m_pEnergyCalculator = new HMFFEnergy(this, data);
             }
             else {
                 std::cout<<" error---> unknown force field type: "<<type<<std::endl;

--- a/version_2.1/dts_src/State.h
+++ b/version_2.1/dts_src/State.h
@@ -84,6 +84,8 @@
 //--- energy calcuation method
 #include "AbstractEnergy.h"
 #include "Energy.h"
+#include "HMFFEnergy.h"
+
 //-- curvature
 #include "AbstractCurvature.h"
 #include "CurvatureByShapeOperatorType1.h"

--- a/version_2.1/dts_src/VertexInScalarFieldPotential.cpp
+++ b/version_2.1/dts_src/VertexInScalarFieldPotential.cpp
@@ -1,0 +1,363 @@
+/*
+  Compute the potential of a point in a scalar field
+
+  U_{em}(R) = \sum_j w_j \cdot V_{em}(r_j)
+  V_{em}(r) = \begin{cases}
+    \m_Xi \left[1 - \frac{\theta(r) - \theta_{thr}}{\theta_{max} -
+  \theta_{thr}}\right] & \text{if } \theta(r) \geq \theta_{thr} \ \m_Xi &
+  \text{if } \theta(r) < \theta_{thr} \end{cases}
+
+  Where:
+
+  - $\theta(r)$ is the scalar field containing EM densities.
+  - $r$ is a position vector in 3D space.
+  - $\m_Xi$ is a force scaling factor.
+  - $\theta_{max}$ is the mam_Ximum value of the densities.
+  - $\theta_{thr}$ is a threshold value to exclude solvent contribution.
+  - $w_j$ is a per-atom weighting factor.
+
+  See the MDFF formalism (https://www.ks.uiuc.edu/Research/mdff/method.html)
+
+  L.G. Trabuco, E. Villa, K. Mitra, J. Frank, and K. Schulten. Structure, 16,
+  673-683 (2008)
+
+  Copyright (c) 2024-2025 European Molecular Biology Laboratory
+
+  Author: Valentin Maurer <valentin.maurer@embl-hamburg.de>
+*/
+#include <cmath>
+#include <numeric>
+#include <vector>
+#include <array>
+#include <algorithm>
+#include <iostream>
+#include <iomanip>
+#include <limits>
+
+inline std::vector<float> gaussDerivative(
+    const unsigned int dim, const unsigned int kernel_size, const double sigma = 1.0
+  ){
+    if (dim >= 3) {
+        throw std::invalid_argument("dim must be < 3");
+    }
+
+    const int m_Offset = kernel_size / 2;
+    std::vector<float> diff(kernel_size);
+    std::vector<float> smooth(kernel_size);
+    std::vector<float> ret(kernel_size * kernel_size * kernel_size);
+
+    const float sigma2 = sigma * sigma;
+    for (int i = 0; i < kernel_size; ++i) {
+        float x = -(static_cast<float>(i) - m_Offset);
+        smooth[i] = std::exp(-(x * x)/(2.0 * sigma2));
+        diff[i] = smooth[i] * (-x/(sigma2));
+    }
+
+    for (int k = 0; k < kernel_size; ++k) {
+        float z_val = (dim == 2) ? diff[k] : smooth[k];
+        for (int j = 0; j < kernel_size; ++j) {
+            float y_val = (dim == 1) ? diff[j] : smooth[j];
+            for (int i = 0; i < kernel_size; ++i) {
+                float x_val = (dim == 0) ? diff[i] : smooth[i];
+                ret[i + kernel_size * (j + kernel_size * k)] = x_val * y_val * z_val;
+            }
+        }
+    }
+
+    return ret;
+}
+
+class HarmonicPotentialCalculator {
+private:
+  const std::vector<float> m_Data; // Volume (x,y,z) with length N = x * y * z.
+  const std::vector<unsigned int> m_Shape;  // Volume shape x, y, z.
+  const std::vector<double> m_Sampling; // Distance/Voxel conversion factor.
+  const std::vector<double> m_Offsets;       // Grid offsets from centering.
+  const double m_DataScaling; // Scaling factor for data to invert contrast.
+  const double m_Xi;       // Force scaling factor.
+  const double m_ThetaThr; // Threshold for density to be foreground.
+  double m_ThetaMax;       // Maximum value in m_Data.
+  const double m_StepSize; // Step size along gradient.
+  const unsigned int m_KernelSize; // Gradient kernel size.
+  const size_t m_StrideY; // y stride of m_Data.
+  const size_t m_StrideZ; // z stride of m_Data.
+  std::vector<float> m_gradient_X; // Gradient kernel in x.
+  std::vector<float> m_gradient_Y; // Gradient kernel in y.
+  std::vector<float> m_gradient_Z; // Gradient kernel in z.
+  std::vector<float> m_boundaryValues; // Per-plane averages used for padding.
+  const float m_Padding = 0.4; // Scaling factor for padding values.
+
+  inline bool isInBounds(const unsigned int x, const unsigned int y, const unsigned int z) const noexcept {
+    return x < m_Shape[0] && y < m_Shape[1] && z < m_Shape[2];
+  }
+
+  inline unsigned int safeDoubleToUInt(const double val) const noexcept {
+    return val < 0.0 ? std::numeric_limits<unsigned int>::max() : static_cast<unsigned int>(val);
+  }
+
+  __attribute__((always_inline))
+  inline float getValue(const int x, const int y, const int z) const noexcept {
+    return m_Data[z * m_StrideZ + y * m_StrideY + x];
+  }
+
+  inline float interpolateTheta(const double x, const double y, const double z) const noexcept {
+    // Wrapping will cause negative values to fail in bounds check
+    const unsigned int x0 = safeDoubleToUInt(x);
+    const unsigned int y0 = safeDoubleToUInt(y);
+    const unsigned int z0 = safeDoubleToUInt(z);
+
+    if (!isInBounds(x0, y0, z0) || !isInBounds(x0 + 1, y0 + 1, z0 + 1)){
+
+      int offset = z0;
+      if (z0 >= m_Shape[2]) {
+          offset = m_Shape[2] - 1;
+          if (z < 0){
+            offset = 0;
+          }
+      }
+
+      return m_Padding * m_boundaryValues[offset] * m_ThetaMax;
+    }
+
+    const float xd = static_cast<float>(x - x0);
+    const float yd = static_cast<float>(y - y0);
+    const float zd = static_cast<float>(z - z0);
+
+    const float xd_comp = 1.0f - xd;
+    const float yd_comp = 1.0f - yd;
+    const float zd_comp = 1.0f - zd;
+
+    const float v000 = getValue(x0, y0, z0);
+    const float v100 = getValue(x0 + 1, y0, z0);
+    const float v010 = getValue(x0, y0 + 1, z0);
+    const float v110 = getValue(x0 + 1, y0 + 1, z0);
+    const float v001 = getValue(x0, y0, z0 + 1);
+    const float v101 = getValue(x0 + 1, y0, z0 + 1);
+    const float v011 = getValue(x0, y0 + 1, z0 + 1);
+    const float v111 = getValue(x0 + 1, y0 + 1, z0 + 1);
+
+    const float c00 = v000 * xd_comp + v100 * xd;
+    const float c10 = v010 * xd_comp + v110 * xd;
+    const float c01 = v001 * xd_comp + v101 * xd;
+    const float c11 = v011 * xd_comp + v111 * xd;
+
+    const float c0 = c00 * yd_comp + c10 * yd;
+    const float c1 = c01 * yd_comp + c11 * yd;
+
+    return m_DataScaling * (c0 * zd_comp + c1 * zd);
+  }
+
+  std::array<double, 3> interpolateThetaGrad(const double x, const double y, const double z) const {
+      std::array<double, 3> gradient = {0.0, 0.0, 0.0};
+
+      if (m_StepSize == 0.0f){
+        return gradient;
+      }
+
+      const unsigned int x0 = safeDoubleToUInt(x);
+      const unsigned int y0 = safeDoubleToUInt(y);
+      const unsigned int z0 = safeDoubleToUInt(z);
+
+      if (!isInBounds(x0, y0, z0) || !isInBounds(x0 + 1, y0 + 1, z0 + 1)){
+        return gradient;
+      }
+
+      // For larger number of vertices, consider pre-computing the volume gradient
+      const int n = m_KernelSize / 2;
+      for (int k = 0; k < m_KernelSize; ++k) {
+          const int zkn = z + k - n;
+          const int km = m_KernelSize * k;
+
+          for (int j = 0; j < m_KernelSize; ++j) {
+              const int ykn = y + j - n;
+              const int jkm = m_KernelSize * (j + km);
+
+              for (int i = 0; i < m_KernelSize; ++i) {
+                  const int idx = i + jkm;
+                  const double val = static_cast<double>(interpolateTheta(x + i - n, ykn, zkn));
+
+                  gradient[0] += val * m_gradient_X[idx];
+                  gradient[1] += val * m_gradient_Y[idx];
+                  gradient[2] += val * m_gradient_Z[idx];
+              }
+          }
+      }
+
+      const double norm = std::sqrt(gradient[0] * gradient[0] +
+                            gradient[1] * gradient[1] +
+                            gradient[2] * gradient[2]);
+      if (norm > 1e-10) {
+        const double scaleFactor = m_StepSize / norm;
+        gradient[0] *= scaleFactor;
+        gradient[1] *= scaleFactor;
+        gradient[2] *= scaleFactor;
+      }
+      return gradient;
+  }
+
+
+void printDebugInfo() const {
+    const int width = 16; // Increased for longer parameter names
+
+    std::cout << "\n===== HMFF Configuration =====\n";
+
+    // Volume information
+    std::cout << std::left << std::setw(width) << "Reference" <<
+      ": (X, Y, Z)" << "\n";
+    std::cout << std::left << std::setw(width) << "Volume Shape" <<
+      ": (" << m_Shape[0] << ", " << m_Shape[1] << ", " << m_Shape[2] << ")\n";
+    std::cout << std::left << std::setw(width) << "Mesh Scaling" <<
+      ": (" << std::fixed << std::setprecision(3)
+            << m_Sampling[0] << ", "
+            << m_Sampling[1] << ", "
+            << m_Sampling[2] << ")\n";
+    std::cout << std::left << std::setw(width) << "Mesh Offset" <<
+      ": (" << std::fixed << std::setprecision(3)
+            << m_Offsets[0] << ", "
+            << m_Offsets[1] << ", "
+            << m_Offsets[2] << ")\n";
+
+    std::cout << std::left << std::setw(width) << "Xi"
+      << ": " << m_Xi << "\n";
+    std::cout << std::left << std::setw(width) << "ThetaThr"
+      << ": " << m_ThetaThr << "\n";
+    std::cout << std::left << std::setw(width) << "ThetaMax"
+      << ": " << m_ThetaMax << "\n";
+    std::cout << std::left << std::setw(width) << "StepSize"
+      << ": " << m_StepSize << "\n";
+    std::cout << std::left << std::setw(width) << "KernelSize"
+      << ": " << m_KernelSize << "\n";
+    std::cout << std::left << std::setw(width) << "DataScaling"
+      << ": " << m_DataScaling << "\n";
+    std::cout << std::left << std::setw(width) << "PaddingFactor"
+      << ": " << m_Padding << "\n\n";
+}
+
+
+public:
+  HarmonicPotentialCalculator(const std::vector<float> &data,
+                              const std::vector<unsigned int> &shape,
+                              const std::vector<double> &sampling,
+                              const double m_Xi,
+                              const double m_ThetaThr,
+                              const std::vector<double> &offsets,
+                              const double m_DataScaling,
+                              const double step_size,
+                              const unsigned int kernel_size = 3,
+                              float data_percentile = 0.999,
+                              const double padding_factor = 0.4)
+      : m_Data(data),
+        m_Shape(shape),
+        m_Sampling(sampling), m_Xi(m_Xi),
+        m_ThetaThr(m_ThetaThr),
+        m_Offsets(offsets),
+        m_DataScaling(m_DataScaling),
+        m_StepSize(step_size),
+        m_KernelSize(kernel_size),
+        m_StrideY(shape[0]),
+        m_StrideZ(shape[0] * shape[1]),
+        m_Padding(padding_factor) {
+
+    if (shape.size() != sampling.size()) {
+      std::cerr << "Shape and sampling rate dimensions must match.\n";
+      exit(1);
+    }
+
+    if (offsets.size() != 3) {
+      std::cerr << "Offsets vector must contain exactly 3 values (x,y,z).\n";
+      exit(1);
+    }
+
+    size_t totalSize = shape[0] * shape[1] * shape[2];
+    if (totalSize != data.size()) {
+      std::cerr << "Data size doesn't match the specified shape.\n";
+      exit(1);
+    }
+
+    std::vector<float> dataCopy = data;
+    float rank = (m_DataScaling > 0 ? data_percentile : 1.0 - data_percentile);
+    size_t k = std::floor(rank * (totalSize - 1));
+    std::nth_element(dataCopy.begin(), dataCopy.begin() + k, dataCopy.end());
+    float theta_max = m_DataScaling * dataCopy[k];
+
+    m_ThetaMax = static_cast<double>(theta_max);
+
+    m_gradient_X = gaussDerivative(0, m_KernelSize, 1.0);
+    m_gradient_Y = gaussDerivative(1, m_KernelSize, 1.0);
+    m_gradient_Z = gaussDerivative(2, m_KernelSize, 1.0);
+
+    // Neighbor weighted per slice z-value
+    m_boundaryValues.resize(shape[2]);
+    for (size_t z = 0; z < shape[2]; ++z) {
+        m_boundaryValues[z] = computePlaneAverage(data, z);
+    }
+
+    std::vector<float> temp = m_boundaryValues;
+    for (size_t z = 0; z < shape[2]; ++z) {
+        if (z == 0) {
+            m_boundaryValues[z] = (temp[z] + temp[z + 1]) / 2.0f;
+        }
+        else if (z == shape[2] - 1) {
+            m_boundaryValues[z] = (temp[z - 1] + temp[z]) / 2.0f;
+        }
+        else {
+            m_boundaryValues[z] = (temp[z - 1] + temp[z] + temp[z + 1]) / 3.0f;
+        }
+    }
+
+    float minVal = *std::min_element(m_boundaryValues.begin(), m_boundaryValues.end());
+    float maxVal = *std::max_element(m_boundaryValues.begin(), m_boundaryValues.end());
+    float range = maxVal - minVal;
+
+    if (range > 0) {
+        for (size_t i = 0; i < m_boundaryValues.size(); ++i) {
+            m_boundaryValues[i] = (m_boundaryValues[i] - minVal) / range;
+        }
+    }
+    else {
+        std::fill(m_boundaryValues.begin(), m_boundaryValues.end(), 0.5f);
+    }
+
+    printDebugInfo();
+  }
+
+
+  float computePlaneAverage(const std::vector<float>& inputData, size_t zIndex) {
+      size_t planeSize = m_Shape[0] * m_Shape[1];
+      size_t startIdx = zIndex * planeSize;
+      size_t endIdx = startIdx + planeSize;
+
+      float sum = 0.0f;
+      for (size_t i = startIdx; i < endIdx; ++i) {
+          sum += std::abs(inputData[i]);
+      }
+      return sum / planeSize;
+  }
+
+  inline double computeEnergy(const double x, const double y, const double z) const noexcept {
+
+    const double scaled_x = (x - m_Offsets[0]) * m_Sampling[0];
+    const double scaled_y = (y - m_Offsets[1]) * m_Sampling[1];
+    const double scaled_z = (z - m_Offsets[2]) * m_Sampling[2];
+
+    const double theta = std::min(
+      static_cast<double>(interpolateTheta(scaled_x, scaled_y, scaled_z)), m_ThetaMax
+    );
+
+    if (theta > m_ThetaThr) {
+      return m_Xi * (1 - (theta - m_ThetaThr) / (m_ThetaMax - m_ThetaThr));
+    }
+    return m_Xi;
+
+  }
+
+  inline std::array<double, 3> computeEnergyGradient(const double x, const double y,
+                              const double z) const {
+    const double scaled_x = (x - m_Offsets[0]) * m_Sampling[0];
+    const double scaled_y = (y - m_Offsets[1]) * m_Sampling[1];
+    const double scaled_z = (z - m_Offsets[2]) * m_Sampling[2];
+
+    return interpolateThetaGrad(scaled_x, scaled_y, scaled_z);
+  }
+
+};


### PR DESCRIPTION
Hi Weria,

This PR adds a new Energy class implementing the HMFF potential.

### Explanation of added files

HMFFEnergy.h/.cpp: New system energy derived from the existing Energy class. This required overriding Energy::SingleVertexEnergy.

VertexInScalarFieldPotential.cpp: Trilinear interpolator of data and corresponding first derivative (using a smooth Gaussian approximation) to compute the energy of a vertex in a scalar field.

MRCParser.cpp: Parser for the CCP4/MRC file format to extract data and header information. Data is read in chunks and stored in memory as one.

### Usage Example

Attached is a [minimal_example.tar.gz](https://github.com/user-attachments/files/20425153/minimal_example.tar.gz)using a planar membrane mesh embedded in a smooth Gaussian potential field.

```
tar -xvzf minimal_example.tar.gz
cd minimal_example
DTS -in input_hmff.dts -top topol.top -seed 76532 -e 100000 -nt 8
```

Running the simulation should take about 5 Minutes / #Thread.

### Notes

A description of the parameters accepted by the HMFFEnergy is given in the corresponding implementation file. The ability to include the first derivative in the vertex update rule is currently deactivated. It could be brought back by modifying EvolveVerticesByMetropolisAlgorithm.cpp

```
bool EvolveVerticesByMetropolisAlgorithm::EvolveOneVertex(int step, vertex *pvertex, double dx, double dy, double dz,double temp){
    
    double old_energy = 0;
    double new_energy = 0;

    Vec3D gradient = m_pState->GetEnergyCalculator()->CalculateGradient(pvertex);
    dx += gradient(0);
    dy += gradient(1);
    dz += gradient(2);
```

HMFFEnergy::SingleVertexEnergy invokes Energy::SingleVertexEnergy, causing a function call to `p_vertex->UpdateEnergy(energy);` before and after adding the potential. In my test cases this worked fine with OpenMP, but I am not entirely sure whether its compatible with it. I chose this implementation because the members of Energy required for this computation are private. Alternatively, we could copy the implementation from the corresponding functions from Energy, but then need to make sure they stay in sync.

Best,
Valentin